### PR TITLE
Version 3.1.0 - Required Env Vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-04-12
+
+### Added
+
+- A way to make evaluating environment variables require a value to be found by 
+  appending `!=` to the end of the expression like so `${__ENV__:API_KEY!=}`. 
+  Missing values will trigger a `ValueError` raised when loading config files.
+
 ## [3.0.0] - 2024-04-11
 
 ### Added

--- a/alviss/__init__.py
+++ b/alviss/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/tests/basic/test_required.py
+++ b/tests/basic/test_required.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+
+from alviss import quickloader
+import yaml
+import json
+
+import logging
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+_HERE = os.path.dirname(__file__)
+
+
+class TestRendering(unittest.TestCase):
+    def setUp(self):
+        os.environ['OS_MOCK'] = 'MockDos'
+        if 'ALVISS_FIDELIUS_MODE' in os.environ:
+            del os.environ['ALVISS_FIDELIUS_MODE']
+        if 'PRETEND_API_KEY' in os.environ:
+            del os.environ['PRETEND_API_KEY']
+
+    def test_yaml_required_should_fail(self):
+        if 'PRETEND_API_KEY' in os.environ:
+            del os.environ['PRETEND_API_KEY']
+        with self.assertRaises(ValueError):
+            quickloader.autoload(os.path.join(_HERE, '../res/rendering/yaml/required_env.yaml'))
+
+    def test_json_required_should_fail(self):
+        if 'PRETEND_API_KEY' in os.environ:
+            del os.environ['PRETEND_API_KEY']
+        with self.assertRaises(ValueError):
+            quickloader.autoload(os.path.join(_HERE, '../res/rendering/json/required_env.json'))
+
+    def test_yaml_required_env(self):
+        os.environ['PRETEND_API_KEY'] = 'veryimportantvalue'
+
+        cfg = quickloader.autoload(os.path.join(_HERE, '../res/rendering/yaml/required_env.yaml'))
+
+        self.assertEqual('veryimportantvalue', cfg.required_key)
+
+        with open(os.path.join(_HERE, '../res/rendering/expected_required.yaml'), 'r') as fin:
+            expected_data = yaml.safe_load(fin)
+
+        self.assertEqual(expected_data, cfg.as_dict(unmaksed=True))
+
+        if 'PRETEND_API_KEY' in os.environ:
+            del os.environ['PRETEND_API_KEY']
+
+    def test_json_required_env(self):
+        os.environ['PRETEND_API_KEY'] = 'veryimportantvalue'
+
+        cfg = quickloader.autoload(os.path.join(_HERE, '../res/rendering/json/required_env.json'))
+
+        self.assertEqual('veryimportantvalue', cfg.required_key)
+
+        with open(os.path.join(_HERE, '../res/rendering/expected_required.json'), 'r') as fin:
+            expected_data = json.load(fin)
+
+        self.assertEqual(expected_data, cfg.as_dict(unmaksed=True))
+
+        if 'PRETEND_API_KEY' in os.environ:
+            del os.environ['PRETEND_API_KEY']

--- a/tests/res/rendering/expected_required.json
+++ b/tests/res/rendering/expected_required.json
@@ -1,0 +1,60 @@
+{
+  "foo": "I am foo",
+  "internal_ref": {
+    "deeper": {
+      "there": "Something",
+      "everywhere": "My heart will go on!"
+    }
+  },
+  "base_key": "is basic",
+  "foo_inherited": "Should be static!",
+  "bar": "This is bar",
+  "group": {
+    "alpha": "AAAAA!",
+    "beta": "B",
+    "gamma_with_var": "Foo:I am foo",
+    "delta": "NewDeltaRocks!"
+  },
+  "collapsed": {
+    "group": {
+      "successful": true,
+      "in": {
+        "one": {
+          "string": "Yes!"
+        }
+      }
+    }
+  },
+  "my_list": [
+    "one",
+    "two",
+    "three",
+    "I am foo",
+    "This is B group",
+    "No ${var}",
+    "${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING}"
+  ],
+  "import_test": {
+    "generic": "Overridden",
+    "because": "that's cool",
+    "imported_key": {
+      "import2": "Tveir",
+      "import1": "one",
+      "import3": "three",
+      "included_env_stuff": "MockDos"
+    }
+  },
+  "required_key": "veryimportantvalue",
+  "a_float": 3.5,
+  "a_bool": true,
+  "a_false_bool": false,
+  "a_none": null,
+  "a_zero": 0,
+  "a_default_env": "I'm a default value!",
+  "an_empty": "",
+  "new_delta": "NewDeltaRocks!",
+  "env_stuff": "MockDos",
+  "an_integer": 7,
+  "another_integer": 42,
+  "should_be_seven": 7
+}

--- a/tests/res/rendering/expected_required.yaml
+++ b/tests/res/rendering/expected_required.yaml
@@ -1,0 +1,48 @@
+foo: I am foo
+internal_ref:
+  deeper:
+    there: Something
+    everywhere: My heart will go on!
+base_key: is basic
+foo_inherited: Should be static!
+bar: This is bar
+group:
+  alpha: AAAAA!
+  beta: B
+  gamma_with_var: Foo:I am foo
+  delta: NewDeltaRocks!
+collapsed:
+  group:
+    successful: true
+    in:
+      one:
+        string: Yes!
+my_list:
+- one
+- two
+- three
+- I am foo
+- This is B group
+- No ${var}
+- ${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING}
+import_test:
+  generic: Overridden
+  because: that's cool
+  imported_key:
+    import2: Tveir
+    import1: one
+    import3: three
+    included_env_stuff: MockDos
+required_key: veryimportantvalue
+a_float: 3.5
+a_bool: true
+a_false_bool: false
+a_none: null
+a_zero: 0
+a_default_env: I'm a default value!
+an_empty: ''
+new_delta: NewDeltaRocks!
+env_stuff: MockDos
+an_integer: 7
+another_integer: 42
+should_be_seven: 7

--- a/tests/res/rendering/json/required_env.json
+++ b/tests/res/rendering/json/required_env.json
@@ -1,0 +1,47 @@
+{
+  "__extends__": "_base_file.json",
+  "foo": "I am foo",
+  "bar": "This is bar",
+  "group": {
+    "alpha": "A",
+    "beta": "B",
+    "__extends__": "_subinclude.json"
+  },
+  "group.delta": "${new_delta}",
+  "collapsed.group.in.one.string": "Yes!",
+  "collapsed.group.__include__": "_collapse_import.json",
+  "my_list": [
+    "one",
+    "two",
+    "three",
+    "${foo}",
+    "This is ${group.beta} group",
+    "No ${var}",
+    "${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING}"
+  ],
+  "import_test": {
+    "__extends__": [
+      "_import.json",
+      "inc/import2.json"
+    ],
+    "generic": "Overridden",
+    "imported_key.import2": "Tveir"
+  },
+  "required_key": "${__ENV__:PRETEND_API_KEY!=}",
+  "an_integer": 1,
+  "a_float": 3.5,
+  "a_bool": true,
+  "a_false_bool": false,
+  "a_none": null,
+  "a_zero": 0,
+  "a_default_env": "${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING_EITHER=I'm a default value!}",
+  "an_empty": "",
+  "__include__": [
+    "_include1.json",
+    "inc/include2.json"
+  ],
+  "foo_inherited": "Should be static!",
+  "should_be_seven": "Nine!",
+  "new_delta": "NewDeltaRocks!",
+  "env_stuff": "${__ENV__:OS_MOCK}"
+}

--- a/tests/res/rendering/yaml/required_env.yaml
+++ b/tests/res/rendering/yaml/required_env.yaml
@@ -1,0 +1,39 @@
+# This is a cool Config File!
+__extends__: _base_file.yaml
+foo: I am foo
+bar: This is bar
+group:
+  alpha: A
+  beta: B
+  __extends__: _subinclude.yaml
+group.delta: ${new_delta}
+collapsed.group.in.one.string: Yes!
+collapsed.group.__include__: _collapse_import.yaml
+my_list:
+- one
+- two
+- three
+- ${foo}
+- This is ${group.beta} group
+- No ${var}
+- ${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING}
+import_test:
+  __extends__: ["_import.yaml", "inc/import2.yaml"]
+  generic: Overridden
+  imported_key.import2: Tveir
+an_integer: 1
+required_key: ${__ENV__:PRETEND_API_KEY!=}
+a_float: 3.5
+a_bool: true
+a_false_bool: false
+a_none: null
+a_zero: 0
+a_default_env: ${__ENV__:I_DONT_WANT_THIS_GUY_TO_RESOLVE_TO_ANYTHING_EITHER=I'm a default value!}
+an_empty: ''
+__include__:
+- _include1.yaml
+- inc/include2.yaml
+foo_inherited: Should be static!
+should_be_seven: Nine!
+new_delta: NewDeltaRocks!
+env_stuff: ${__ENV__:OS_MOCK}


### PR DESCRIPTION
### Added

- A way to make evaluating environment variables require a value to be found by appending `!=` to the end of the expression like so `${__ENV__:API_KEY!=}`. Missing values will trigger a `ValueError` raised when loading config files.