### PR TITLE
Version 3.2.2 - Stubber fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.2.2] - 2024-05-06
+
+### Fixed
+
+- Stubber CLI was ignoring the class name when using the `-o` output flag
+
+
 ## [3.2.1] - 2024-04-29
 
 ### Changed

--- a/alviss/__init__.py
+++ b/alviss/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/alviss/cli/stubber/main.py
+++ b/alviss/cli/stubber/main.py
@@ -35,6 +35,10 @@ def main():
     if not args.silent:
         print(f'Reading and stubbing file: {args.file}...')
 
+    cls_name = 'AlvissConfigStub' if args.class_name is None else args.class_name
+    if cls_name.lower().strip() == 'none':
+        cls_name = ''
+
     try:
         if args.output:
             if not args.silent:
@@ -43,14 +47,13 @@ def main():
             stubber.SimpleStubMaker().render_stub_classes_to_file(input_file=args.file,
                                                                   output_file=args.output,
                                                                   overwrite_existing=args.force_overwrite,
-                                                                  is_private=not args.export_all)
+                                                                  is_private=not args.export_all,
+                                                                  class_name=cls_name)
         else:
             if not args.silent:
                 print(f'Printing results:')
                 print(f'==================================================')
-            cls_name = 'AlvissConfigStub' if args.class_name is None else args.class_name
-            if cls_name.lower().strip() == 'none':
-                cls_name = ''
+
             print(stubber.SimpleStubMaker().render_stub_classes_from_descriptor_file(args.file, class_name=cls_name, is_private=not args.export_all))
 
             if not args.silent:

--- a/alviss/stubber/stubmaker/_simple.py
+++ b/alviss/stubber/stubmaker/_simple.py
@@ -56,12 +56,12 @@ from alviss.structs import BaseConfig
 
 {class_str}{root_cls}"""
 
-    def render_stub_classes_to_file(self, input_file: str, output_file: str, overwrite_existing: bool = False, is_private: bool = True):
+    def render_stub_classes_to_file(self, input_file: str, output_file: str, overwrite_existing: bool = False, is_private: bool = True, class_name: str = 'AlvissConfigStub'):
         out = pathlib.Path(output_file).absolute()
         if out.exists() and not overwrite_existing:
             raise AlvissFileAlreadyExistsError('Output file already exists', file_name=output_file)
 
-        results = self.render_stub_classes_from_descriptor_file(input_file, is_private=is_private)
+        results = self.render_stub_classes_from_descriptor_file(input_file, is_private=is_private, class_name=class_name)
 
         if not out.parent.exists():
             log.debug(f'Creating output path: {out.parent}')

--- a/alviss/stubber/stubmaker/interface.py
+++ b/alviss/stubber/stubmaker/interface.py
@@ -15,7 +15,8 @@ class IStubMaker(abc.ABC):
 
     @abc.abstractmethod
     def render_stub_classes_to_file(self, input_file: str, output_file: str,
-                                    overwrite_existing: bool = False, is_private: bool = True):
+                                    overwrite_existing: bool = False, is_private: bool = True,
+                                    class_name: str = 'AlvissConfigStub'):
         """Writer the results of the `render_stub_classes_from_descriptor_file`
         call to the given output file.
         """


### PR DESCRIPTION
### Fixed

- Stubber CLI was ignoring the class name when using the `-o` output flag