### PR TITLE
Version 3.3.0 - Python import injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2024-05-30
+
+## Added
+
+- A new expression for injecting values imported from/via Python like so 
+  `${__PY__:alviss.__version__}`
+  - This uses the `ccptools.tpu.strimp.get_any(...)` to import whatever the 
+    expression key points to and inject into the parsed config
+  - The use case here is mainly to inject dynamic Python values into Alviss 
+    files "on-demand" like when using [ccp-stencil](https://github.com/ccpgames/ccp-stencil) 
+    templates in a CI/CD pipe so you can have the ever-changing version of the 
+    package you're working on injected automatically into the Alviss config file 
+    used as Context for rendering Docker files, Kube manifests and so on 
+    (similar to how it can be done in `pyproject.toml`)
+  - This expression also adheres to the normal format of "defaults" (e.g. 
+    `${__PY__:alviss.__version__=Unknown}`) and "required" (e.g. 
+    `${__PY__:alviss.__version__!=}`)
+
+
 
 ## [3.2.2] - 2024-05-06
 

--- a/alviss/__init__.py
+++ b/alviss/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.2'
+__version__ = '3.3.0-dev.1'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/alviss/loaders/autoloader.py
+++ b/alviss/loaders/autoloader.py
@@ -29,7 +29,7 @@ def guess_loader_class(file_name: str) -> Type[IAlvissLoader]:
     return loader
 
 
-def raw_load(file_name: str, skip_env_loading: bool = False, skip_fidelius: bool = False, encoding: str = 'utf-8') -> Dict:
+def raw_load(file_name: str, skip_env_loading: bool = False, skip_fidelius: bool = False, skip_py_inject: bool = False, encoding: str = 'utf-8') -> Dict:
     """Loads and parses the given config file and returns the "raw" results as a
     simple python dictionary.
 
@@ -39,15 +39,17 @@ def raw_load(file_name: str, skip_env_loading: bool = False, skip_fidelius: bool
     :param file_name: The file to load
     :param skip_env_loading: Set to True to skip resolving environment variable tags
     :param skip_fidelius: Set to True to skip resolving Fidelius tags
+    :param skip_py_inject: Set to True to skip injecting Python imported values
     :param encoding: Encoding to use when reading the file (utf-8 by default)
     :return: A dict with the results
     """
     loader = guess_loader_class(file_name)()
-    loader.load_file(file_name, no_env_load=skip_env_loading, no_fidelius=skip_fidelius, encoding=encoding)
+    loader.load_file(file_name, no_env_load=skip_env_loading, no_fidelius=skip_fidelius,
+                     no_py_inject=skip_py_inject, encoding=encoding)
     return loader.data
 
 
-def render_load(file_name: str, skip_env_loading: bool = True, skip_fidelius: bool = True, encoding: str = 'utf-8') -> str:
+def render_load(file_name: str, skip_env_loading: bool = True, skip_fidelius: bool = True, skip_py_inject: bool = True, encoding: str = 'utf-8') -> str:
     """Loads and parses the given config file and returns the "render" results
     as a str in the same format the original file used.
 
@@ -65,12 +67,13 @@ def render_load(file_name: str, skip_env_loading: bool = True, skip_fidelius: bo
     :param skip_env_loading: Set to True to skip resolving environment variable
                              tags
     :param skip_fidelius: Set to True to skip resolving Fidelius tags
+    :param skip_py_inject: Set to True to skip injecting Python imported values
     :param encoding: Encoding to use when reading the file (utf-8 by default)
     :return: A string representation of the configuration data loaded, in the
              same format as the target file if possible
     """
     loader = guess_loader_class(file_name)()
-    loader.load_file(file_name, no_env_load=skip_env_loading, no_fidelius=skip_fidelius, encoding=encoding)
+    loader.load_file(file_name, no_env_load=skip_env_loading, no_fidelius=skip_fidelius, no_py_inject=skip_py_inject, encoding=encoding)
     return loader.rendered
 
 

--- a/alviss/loaders/interface.py
+++ b/alviss/loaders/interface.py
@@ -44,6 +44,7 @@ class IAlvissLoader(abc.ABC):
                   no_includes: bool = False,
                   no_env_load: bool = False,
                   no_fidelius: bool = False,
+                  no_py_inject: bool = False,
                   encoding: str = 'utf-8'):
         """Loads a config file.
 
@@ -53,6 +54,7 @@ class IAlvissLoader(abc.ABC):
         :param no_includes:
         :param no_env_load:
         :param no_fidelius:
+        :param no_py_inject:
         :param encoding:
         """
         pass
@@ -64,7 +66,7 @@ class IAlvissLoader(abc.ABC):
     @abc.abstractmethod
     def load_raw(self, raw_data: str, no_resolve: bool = False,
                  no_extend: bool = False, no_includes: bool = False, no_env_load: bool = False,
-                 no_fidelius: bool = False):
+                 no_fidelius: bool = False, no_py_inject: bool = False):
         """Loads configuration data directly from a string.
 
         The `load_file` method basically just reads a file and passes its

--- a/alviss/loaders/jsonfile.py
+++ b/alviss/loaders/jsonfile.py
@@ -24,7 +24,14 @@ class JsonFileConfigLoader(BaseLoader):
 
     def load_raw(self, raw_data: str, no_resolve: bool = False,
                  no_extend: bool = False, no_includes: bool = False, no_env_load: bool = False,
-                 no_fidelius: bool = False):
+                 no_fidelius: bool = False, no_py_inject: bool = False):
+        self._skip_resolve = no_resolve
+        self._skip_env_loading = no_env_load
+        self._skip_includes = no_includes
+        self._skip_extends = no_extend
+        self._skip_fidelius = no_fidelius
+        self._skip_py_inject = no_py_inject
+
         self._data = self._load_dict(json.loads(raw_data))
         self._set_chains()
         if not no_extend:

--- a/alviss/loaders/yamlfile.py
+++ b/alviss/loaders/yamlfile.py
@@ -12,7 +12,13 @@ log = logging.getLogger(__name__)
 class YamlFileConfigLoader(BaseLoader):
     def load_raw(self, raw_data: str, no_resolve: bool = False,
                  no_extend: bool = False, no_includes: bool = False, no_env_load: bool = False,
-                 no_fidelius: bool = False):
+                 no_fidelius: bool = False, no_py_inject: bool = False):
+        self._skip_resolve = no_resolve
+        self._skip_env_loading = no_env_load
+        self._skip_includes = no_includes
+        self._skip_extends = no_extend
+        self._skip_fidelius = no_fidelius
+        self._skip_py_inject = no_py_inject
         self._data = self._load_dict(yaml.safe_load(raw_data))
         self._set_chains()
         if not no_extend:

--- a/tests/nofidelius/test_py_inject.py
+++ b/tests/nofidelius/test_py_inject.py
@@ -1,0 +1,33 @@
+import unittest
+import os
+from alviss import quickloader
+from alviss.structs.errors import *
+
+from alviss import __version__ as expected_version
+
+import logging
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+_HERE = os.path.dirname(__file__)
+
+
+class TestPyInject(unittest.TestCase):
+    def test_python_inject(self):
+        config = quickloader.autoload(os.path.join(_HERE, '../res/py_inject.yaml'))
+        self.assertIsInstance(config, quickloader.BaseConfig)
+        self.assertEqual(expected_version, config.foo.bar.version)
+
+    def test_python_inject_fail(self):
+        config = quickloader.autoload(os.path.join(_HERE, '../res/py_inject_fail.yaml'))
+        self.assertIsInstance(config, quickloader.BaseConfig)
+        self.assertEqual('${__PY__:thisisnotarealmodule.__version__}', config.foo.bar.version)
+
+    def test_python_inject_cant_fail(self):
+        with self.assertRaises(AlvissSyntaxError):
+            config = quickloader.autoload(os.path.join(_HERE, '../res/py_inject_cant_fail.yaml'))
+
+    def test_python_inject_default(self):
+        config = quickloader.autoload(os.path.join(_HERE, '../res/py_inject_default.yaml'))
+        self.assertIsInstance(config, quickloader.BaseConfig)
+        self.assertEqual('0.1.0-dev.1', config.foo.bar.version)

--- a/tests/res/py_inject.yaml
+++ b/tests/res/py_inject.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    version: ${__PY__:alviss.__version__}

--- a/tests/res/py_inject_cant_fail.yaml
+++ b/tests/res/py_inject_cant_fail.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    version: ${__PY__:thisisnotarealmodule.__version__!=}

--- a/tests/res/py_inject_default.yaml
+++ b/tests/res/py_inject_default.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    version: ${__PY__:thisisnotarealmodule.__version__=0.1.0-dev.1}

--- a/tests/res/py_inject_fail.yaml
+++ b/tests/res/py_inject_fail.yaml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    version: ${__PY__:thisisnotarealmodule.__version__}


### PR DESCRIPTION
## Added

- A new expression for injecting values imported from/via Python like so `${__PY__:alviss.__version__}`
  - This uses the `ccptools.tpu.strimp.get_any(...)` to import whatever the expression key points to and inject into the parsed config
  - The use case here is mainly to inject dynamic Python values into Alviss files "on-demand" like when using [ccp-stencil](https://github.com/ccpgames/ccp-stencil) templates in a CI/CD pipe so you can have the ever-changing version of the package you're working on injected automatically into the Alviss config file used as Context for rendering Docker files, Kube manifests and so on (similar to how it can be done in `pyproject.toml`)
  - This expression also adheres to the normal format of "defaults" (e.g. `${__PY__:alviss.__version__=Unknown}`) and "required" (e.g. `${__PY__:alviss.__version__!=}`)